### PR TITLE
Remove Footer Height

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -52,7 +52,6 @@ footer {
   @include desktop {
     width: 300px;
     padding-top: 50px;
-    height: 300px;
   }
 }
 


### PR DESCRIPTION
Small change to remove the fixed height of 300px from the footer so there isn't extra empty space at the bottom of the page.